### PR TITLE
Busqueda global

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="23" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="23" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/segar-backend/src/main/java/com/segar/backend/dashboard/api/DashboardController.java
+++ b/segar-backend/src/main/java/com/segar/backend/dashboard/api/DashboardController.java
@@ -65,5 +65,13 @@ public class DashboardController {
         return ResponseEntity.ok(dashboardService.getTramiteDetalle(id));
     }
 
+    @GetMapping("/busqueda")
+    public ResponseEntity<BusquedaGlobalDTO> busquedaGlobal(
+            @RequestParam(name = "q", required = true) String query,
+            @RequestParam(name = "limitTramites", required = false, defaultValue = "10") int limitTramites,
+            @RequestParam(name = "limitRegistros", required = false, defaultValue = "10") int limitRegistros
+    ) {
+        return ResponseEntity.ok(dashboardService.busquedaGlobal(query, limitTramites, limitRegistros));
+    }
 
 }

--- a/segar-backend/src/main/java/com/segar/backend/dashboard/domain/dto/BusquedaGlobalDTO.java
+++ b/segar-backend/src/main/java/com/segar/backend/dashboard/domain/dto/BusquedaGlobalDTO.java
@@ -1,0 +1,44 @@
+package com.segar.backend.dashboard.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BusquedaGlobalDTO {
+    private List<ResultadoTramiteDTO> tramites;
+    private List<ResultadoRegistroDTO> registros;
+    private int totalTramites;
+    private int totalRegistros;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResultadoTramiteDTO {
+        private Long id;
+        private String radicadoNumber;
+        private String productName;
+        private String procedureType;
+        private String currentStatus;
+        private LocalDate submissionDate;
+        private LocalDateTime lastUpdate;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResultadoRegistroDTO {
+        private Long id;
+        private String numeroRegistro;
+        private String productName;
+        private String estado;
+        private LocalDate fechaExpedicion;
+        private LocalDate fechaVencimiento;
+    }
+}

--- a/segar-backend/src/main/java/com/segar/backend/dashboard/domain/dto/BusquedaGlobalDTO.java
+++ b/segar-backend/src/main/java/com/segar/backend/dashboard/domain/dto/BusquedaGlobalDTO.java
@@ -38,7 +38,7 @@ public class BusquedaGlobalDTO {
         private String numeroRegistro;
         private String productName;
         private String estado;
-        private LocalDate fechaExpedicion;
-        private LocalDate fechaVencimiento;
+        private LocalDateTime fechaExpedicion;
+        private LocalDateTime fechaVencimiento;
     }
 }

--- a/segar-backend/src/main/java/com/segar/backend/dashboard/infrastructure/DashboardQueryRepository.java
+++ b/segar-backend/src/main/java/com/segar/backend/dashboard/infrastructure/DashboardQueryRepository.java
@@ -159,5 +159,14 @@ public class DashboardQueryRepository {
                         "lower(p.nombre) like lower(concat('%', :query, '%'))"
         ).setParameter("query", query).getSingleResult()).intValue();
     }
+    public List<Object[]> registrosSanitariosRecientes(int limit) {
+        return em.createQuery(
+                "select r.id, r.numeroRegistro, p.nombre, r.estado, r.fechaExpedicion, r.fechaVencimiento " +
+                        "from RegistroSanitario r join Producto p on r.productoId = p.id " +
+                        "order by r.numeroRegistro asc",
+                Object[].class
+        ).setMaxResults(limit).getResultList();
+    }
+
 
 }

--- a/segar-backend/src/main/java/com/segar/backend/dashboard/infrastructure/DashboardQueryRepository.java
+++ b/segar-backend/src/main/java/com/segar/backend/dashboard/infrastructure/DashboardQueryRepository.java
@@ -115,5 +115,49 @@ public class DashboardQueryRepository {
         ).setParameter("tramiteId", tramiteId).getResultList();
     }
 
+    //Busqueda global
+
+    public List<Object[]> buscarTramites(String query, int limit) {
+        return em.createQuery(
+                        "select t.id, t.radicadoNumber, t.productName, t.procedureType, t.currentStatus, t.submissionDate, t.lastUpdate " +
+                                "from Tramite t where " +
+                                "lower(t.radicadoNumber) like lower(concat('%', :query, '%')) or " +
+                                "lower(t.productName) like lower(concat('%', :query, '%')) or " +
+                                "lower(t.procedureType) like lower(concat('%', :query, '%')) " +
+                                "order by t.lastUpdate desc",
+                        Object[].class
+                ).setParameter("query", query)
+                .setMaxResults(limit)
+                .getResultList();
+    }
+
+    public List<Object[]> buscarRegistrosSanitarios(String query, int limit) {
+        return em.createQuery(
+                        "select r.id, r.numeroRegistro, p.nombre, r.estado, r.fechaExpedicion, r.fechaVencimiento " +
+                                "from RegistroSanitario r join Producto p on r.productoId = p.id where " +
+                                "lower(r.numeroRegistro) like lower(concat('%', :query, '%')) or " +
+                                "lower(p.nombre) like lower(concat('%', :query, '%')) " +
+                                "order by r.fechaExpedicion desc",
+                        Object[].class
+                ).setParameter("query", query)
+                .setMaxResults(limit)
+                .getResultList();
+    }
+    public int countTramitesBusqueda(String query) {
+        return ((Number) em.createQuery(
+                "select count(t) from Tramite t where " +
+                        "lower(t.radicadoNumber) like lower(concat('%', :query, '%')) or " +
+                        "lower(t.productName) like lower(concat('%', :query, '%')) or " +
+                        "lower(t.procedureType) like lower(concat('%', :query, '%'))"
+        ).setParameter("query", query).getSingleResult()).intValue();
+    }
+
+    public int countRegistrosBusqueda(String query) {
+        return ((Number) em.createQuery(
+                "select count(r) from RegistroSanitario r join Producto p on r.productoId = p.id where " +
+                        "lower(r.numeroRegistro) like lower(concat('%', :query, '%')) or " +
+                        "lower(p.nombre) like lower(concat('%', :query, '%'))"
+        ).setParameter("query", query).getSingleResult()).intValue();
+    }
 
 }

--- a/segar-backend/src/main/java/com/segar/backend/dashboard/service/DashboardService.java
+++ b/segar-backend/src/main/java/com/segar/backend/dashboard/service/DashboardService.java
@@ -195,43 +195,72 @@ public class DashboardService {
     //Busqueda Global
 
     public BusquedaGlobalDTO busquedaGlobal(String query, int limitTramites, int limitRegistros) {
-        if (query == null || query.trim().isEmpty()) {
-            return new BusquedaGlobalDTO(List.of(), List.of(), 0, 0);
+        String queryTrimmed = (query != null) ? query.trim() : "";
+
+        List<Object[]> tramitesData;
+        List<Object[]> registrosData;
+        int totalTramites;
+        int totalRegistros;
+        boolean esConsultaVacia = queryTrimmed.isEmpty();
+
+        if (esConsultaVacia) {
+            // Si la query está vacía, traer los primeros registros ordenados
+            tramitesData = queryRepository.tramitesRecientes(limitTramites);
+            registrosData = queryRepository.registrosSanitariosRecientes(limitRegistros);
+            totalTramites = (int) queryRepository.totalTramites();
+            totalRegistros = (int) queryRepository.totalRegistros();
+        } else {
+            // Búsqueda normal con filtros
+            tramitesData = queryRepository.buscarTramites(queryTrimmed, limitTramites);
+            registrosData = queryRepository.buscarRegistrosSanitarios(queryTrimmed, limitRegistros);
+            totalTramites = queryRepository.countTramitesBusqueda(queryTrimmed);
+            totalRegistros = queryRepository.countRegistrosBusqueda(queryTrimmed);
         }
 
-        String queryTrimmed = query.trim();
+        // Mapear trámites con lógica diferente según el origen
+        List<BusquedaGlobalDTO.ResultadoTramiteDTO> tramites;
 
-        // Buscar trámites
-        List<Object[]> tramitesData = queryRepository.buscarTramites(queryTrimmed, limitTramites);
-        List<BusquedaGlobalDTO.ResultadoTramiteDTO> tramites = tramitesData.stream()
-                .map(row -> new BusquedaGlobalDTO.ResultadoTramiteDTO(
-                        ((Number) row[0]).longValue(),
-                        (String) row[1],
-                        (String) row[2],
-                        (String) row[3],
-                        String.valueOf(row[4]),
-                        (LocalDate) row[5],
-                        (LocalDateTime) row[6]
-                )).toList();
+        if (esConsultaVacia) {
+            // Mapeo para tramitesRecientes (6 campos, sin submissionDate)
+            tramites = tramitesData.stream()
+                    .map(row -> new BusquedaGlobalDTO.ResultadoTramiteDTO(
+                            ((Number) row[0]).longValue(),
+                            (String) row[1],
+                            (String) row[2],
+                            (String) row[3],
+                            String.valueOf(row[4]),
+                            null,                    // submissionDate no disponible
+                            (LocalDateTime) row[5]   // lastUpdate en posición 5
+                    )).toList();
+        } else {
+            // Mapeo para buscarTramites (7 campos, con submissionDate)
+            tramites = tramitesData.stream()
+                    .map(row -> new BusquedaGlobalDTO.ResultadoTramiteDTO(
+                            ((Number) row[0]).longValue(),
+                            (String) row[1],
+                            (String) row[2],
+                            (String) row[3],
+                            String.valueOf(row[4]),
+                            (LocalDate) row[5],      // submissionDate en posición 5
+                            (LocalDateTime) row[6]   // lastUpdate en posición 6
+                    )).toList();
+        }
 
-        // Buscar registros sanitarios - ESTA LÍNEA FALTABA
-        List<Object[]> registrosData = queryRepository.buscarRegistrosSanitarios(queryTrimmed, limitRegistros);
+        // Mapear registros sanitarios (sin cambios)
         List<BusquedaGlobalDTO.ResultadoRegistroDTO> registros = registrosData.stream()
                 .map(row -> new BusquedaGlobalDTO.ResultadoRegistroDTO(
                         ((Number) row[0]).longValue(),
                         (String) row[1],
-                        (String) row[2], // nombre del producto desde el join
+                        (String) row[2],
                         String.valueOf(row[3]),
-                        ((LocalDateTime) row[4]).toLocalDate(), // convertir a LocalDate
-                        ((LocalDateTime) row[5]).toLocalDate()  // convertir a LocalDate
+                        (LocalDateTime) row[4],
+                        (LocalDateTime) row[5]
                 )).toList();
-
-        // Contar totales
-        int totalTramites = queryRepository.countTramitesBusqueda(queryTrimmed);
-        int totalRegistros = queryRepository.countRegistrosBusqueda(queryTrimmed);
 
         return new BusquedaGlobalDTO(tramites, registros, totalTramites, totalRegistros);
     }
+
+
 
 
 }

--- a/segar-backend/src/main/java/com/segar/backend/dashboard/service/DashboardService.java
+++ b/segar-backend/src/main/java/com/segar/backend/dashboard/service/DashboardService.java
@@ -192,4 +192,46 @@ public class DashboardService {
         }
     }
 
+    //Busqueda Global
+
+    public BusquedaGlobalDTO busquedaGlobal(String query, int limitTramites, int limitRegistros) {
+        if (query == null || query.trim().isEmpty()) {
+            return new BusquedaGlobalDTO(List.of(), List.of(), 0, 0);
+        }
+
+        String queryTrimmed = query.trim();
+
+        // Buscar trámites
+        List<Object[]> tramitesData = queryRepository.buscarTramites(queryTrimmed, limitTramites);
+        List<BusquedaGlobalDTO.ResultadoTramiteDTO> tramites = tramitesData.stream()
+                .map(row -> new BusquedaGlobalDTO.ResultadoTramiteDTO(
+                        ((Number) row[0]).longValue(),
+                        (String) row[1],
+                        (String) row[2],
+                        (String) row[3],
+                        String.valueOf(row[4]),
+                        (LocalDate) row[5],
+                        (LocalDateTime) row[6]
+                )).toList();
+
+        // Buscar registros sanitarios - ESTA LÍNEA FALTABA
+        List<Object[]> registrosData = queryRepository.buscarRegistrosSanitarios(queryTrimmed, limitRegistros);
+        List<BusquedaGlobalDTO.ResultadoRegistroDTO> registros = registrosData.stream()
+                .map(row -> new BusquedaGlobalDTO.ResultadoRegistroDTO(
+                        ((Number) row[0]).longValue(),
+                        (String) row[1],
+                        (String) row[2], // nombre del producto desde el join
+                        String.valueOf(row[3]),
+                        ((LocalDateTime) row[4]).toLocalDate(), // convertir a LocalDate
+                        ((LocalDateTime) row[5]).toLocalDate()  // convertir a LocalDate
+                )).toList();
+
+        // Contar totales
+        int totalTramites = queryRepository.countTramitesBusqueda(queryTrimmed);
+        int totalRegistros = queryRepository.countRegistrosBusqueda(queryTrimmed);
+
+        return new BusquedaGlobalDTO(tramites, registros, totalTramites, totalRegistros);
+    }
+
+
 }

--- a/segar-backend/src/main/java/com/segar/backend/shared/infrastructure/TramiteRepository.java
+++ b/segar-backend/src/main/java/com/segar/backend/shared/infrastructure/TramiteRepository.java
@@ -2,8 +2,13 @@ package com.segar.backend.shared.infrastructure;
 
 import com.segar.backend.shared.domain.Tramite;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.util.List;
 
 
 public interface TramiteRepository extends JpaRepository<Tramite, Long> {
+
 }

--- a/segar-backend/src/main/java/com/segar/backend/tramites/infrastructure/RegistroSanitarioRepository.java
+++ b/segar-backend/src/main/java/com/segar/backend/tramites/infrastructure/RegistroSanitarioRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -30,4 +31,5 @@ public interface RegistroSanitarioRepository extends JpaRepository<RegistroSanit
 
     @Query("SELECT COUNT(r) FROM RegistroSanitario r WHERE YEAR(r.fechaExpedicion) = :year")
     Long countByYear(@Param("year") int year);
+
 }

--- a/segar-backend/src/main/java/com/segar/backend/tramites/service/TramiteServiceImpl.java
+++ b/segar-backend/src/main/java/com/segar/backend/tramites/service/TramiteServiceImpl.java
@@ -50,6 +50,10 @@ public class TramiteServiceImpl{
     @Autowired
     private PreferenciasNotificacionRepository prefRepo;
 
+    @Autowired
+    private RegistroSanitarioRepository registroSanitarioRepository;
+
+
     public TrackingDTO getTracking(Long tramiteId) {
         Tramite t = tramiteRepo.findById(tramiteId).orElseThrow();
         long days = ChronoUnit.DAYS.between(t.getSubmissionDate(), LocalDate.now());


### PR DESCRIPTION
This pull request adds a global search ("búsqueda global") feature to the dashboard backend, allowing users to search for both "Trámites" and "Registros Sanitarios" by a query string, with support for limits and result counts. It introduces a new DTO for returning combined search results, implements repository queries for efficient searching and counting, and exposes a new API endpoint for the feature.

**Global Search Feature Implementation:**

* Added a new API endpoint `/dashboard/busqueda` in `DashboardController` to handle global search requests, accepting query and limit parameters and returning a `BusquedaGlobalDTO` with results.
* Implemented the `BusquedaGlobalDTO` class to encapsulate search results for both "Trámites" and "Registros Sanitarios", including result lists and total counts.
* Added the `busquedaGlobal` method in `DashboardService` to coordinate the search logic, including handling empty queries, mapping results, and aggregating counts.

**Repository and Query Enhancements:**

* Added new methods in `DashboardQueryRepository` for searching and counting "Trámites" and "Registros Sanitarios" based on a query, as well as retrieving recent records for empty queries.
* Minor imports and dependency updates in related repository and service classes to support the new feature. [[1]](diffhunk://#diff-9604529f6bad71b25ac94b9546ed4fd8ca8a3019b711cdc05559d3931891494dR5-R13) [[2]](diffhunk://#diff-ca1ae2f47f64e52e855ae20055b829a1e539e8c2fed9a93a193aa708295f5a2dR10) [[3]](diffhunk://#diff-ca1ae2f47f64e52e855ae20055b829a1e539e8c2fed9a93a193aa708295f5a2dR34) [[4]](diffhunk://#diff-cdbdabc48987ae823490fe4213348c40e46cf1cc61cc09f59ef7707fe47882dbR53-R56)

**Configuration:**

* Updated the project language level in `.idea/misc.xml` from JDK 21 to JDK 23.